### PR TITLE
Fix unknown method name error

### DIFF
--- a/package.js
+++ b/package.js
@@ -23,7 +23,7 @@ Package.onUse(function(api) {
     'underscore',
     'mousetrap:mousetrap@1.4.6_1',
     'jquery',
-	'reactive-dict'
+    'reactive-dict'
   ]);
   api.use('constellation:console@1.2.1', {weak: true});
 


### PR DESCRIPTION
It is possible that messages (including method calls) are sent before the package is initialized.

Currently, in this case we get an error in the `methodName` template helper, that is unable to get the method name when a result arrives.

In my case, `autoupdate`, `accounts-base` and `ddp` itself send messages before ddp-inspector wraps the ddp methods.

It currently seems that there is no reasonable way to force the package to load before certain packages, as noted in https://github.com/meteor/meteor/issues/3781 (and even if there were, it could complicate the dependency graph).

It might be possible to get the method name from the ddp connection's `_outstandingMethodBlocks`, which contains methods that have outstanding callbacks.

My current solution is to cache those method names when the package loads. If the method call is not registered by ddp-inspector (and therefore it is not in the collection), we try searching for it in the cache, and if that fails, display `(unknown method)`.
